### PR TITLE
Fix phpunit const redefine

### DIFF
--- a/src/__stubs.php
+++ b/src/__stubs.php
@@ -1,6 +1,14 @@
 <?php
 
+/*
+ * This stub file exists to assist IDEs with their code intelligence parsers.
+ */
+
 namespace Yay {
+
+    // Prevent accidental execution
+    goto yay_stubs_skip;
+
     /*
      * Define constants here: https://youtrack.jetbrains.com/issue/WI-7847
      *
@@ -10,6 +18,7 @@ namespace Yay {
      * This file exists because PHPStorm 10.0.3 does not yet have support for namespaced defines.
      */
 
+    /** @noinspection PhpUnreachableStatementInspection */
     const LAYER_DELIMITERS = [
         '{' => 1,
         T_CURLY_OPEN => 1,
@@ -23,4 +32,6 @@ namespace Yay {
 
     const CONSUME_DO_TRIM = 0x10;
     const CONSUME_NO_TRIM = 0x01;
+
+    yay_stubs_skip:
 }

--- a/src/__stubs.php
+++ b/src/__stubs.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yay {
+    /*
+     * Define constants here: https://youtrack.jetbrains.com/issue/WI-7847
+     *
+     * define() must be used because "const" is compile-time and the current way tests are run,
+     * constants need to be loaded multiple times hence the need for conditional constants.
+     *
+     * This file exists because PHPStorm 10.0.3 does not yet have support for namespaced defines.
+     */
+
+    const LAYER_DELIMITERS = [
+        '{' => 1,
+        T_CURLY_OPEN => 1,
+        T_DOLLAR_OPEN_CURLY_BRACES => 1,
+        '}' => -1,
+        '[' => 1,
+        ']' => -1,
+        '(' => 1,
+        ')' => -1,
+    ];
+
+    const CONSUME_DO_TRIM = 0x10;
+    const CONSUME_NO_TRIM = 0x01;
+}

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -289,16 +289,18 @@ function between(Parser $a, Parser $b, Parser $c): Parser
     };
 }
 
-const LAYER_DELIMITERS = [
-    '{' => 1,
-    T_CURLY_OPEN => 1,
-    T_DOLLAR_OPEN_CURLY_BRACES => 1,
-    '}' => -1,
-    '[' => 1,
-    ']' => -1,
-    '(' => 1,
-    ')' => -1,
-];
+if(!defined(__NAMESPACE__."\\LAYER_DELIMITERS")) {
+    define(__NAMESPACE__."\\LAYER_DELIMITERS", [
+        '{' => 1,
+        T_CURLY_OPEN => 1,
+        T_DOLLAR_OPEN_CURLY_BRACES => 1,
+        '}' => -1,
+        '[' => 1,
+        ']' => -1,
+        '(' => 1,
+        ')' => -1,
+    ]);
+}
 
 function layer(array $delimiters = LAYER_DELIMITERS) : Parser
 {
@@ -475,10 +477,8 @@ function either(Parser ...$routes) : Parser
     };
 }
 
-const
-    CONSUME_DO_TRIM = 0x10,
-    CONSUME_NO_TRIM = 0x01
-;
+if(!defined(__NAMESPACE__."\\CONSUME_DO_TRIM")) define(__NAMESPACE__."\\CONSUME_DO_TRIM", 0x10);
+if(!defined(__NAMESPACE__."\\CONSUME_NO_TRIM")) define(__NAMESPACE__."\\CONSUME_NO_TRIM", 0x01);
 
 function consume(Parser $parser, int $trim = CONSUME_NO_TRIM) : Parser
 {


### PR DESCRIPTION
Fixes error `PHPUnit_Framework_Exception: PHP Notice:  Constant yay\LAYER_DELIMITERS already defined in /home/sekjun9878/Documents/Development/Projects/yay/src/parsers.php on line 301`

PHPUnit tests all green after this patch.