### PR TITLE
Updated PHP Parser version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "7.*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "nikic/php-parser": "^2.0"
+        "nikic/php-parser": "^2.0|^3.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
This allows Yay to be installed in a Laravel 5.4 application, which means Pre macros can be used in Laravel projects.

Tests look good, after this change.