### PR TITLE
[WIP] Add tests and started implementation of an expression parser

### DIFF
--- a/src/parsers.php
+++ b/src/parsers.php
@@ -8,7 +8,7 @@ use
 
 function variable(): Parser
 {
-    return rtoken('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/');
+    return rtoken('/\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/');
 }
 
 function phpOperator(): Parser

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -71,13 +71,29 @@ function expr(): Parser
 
     return either(
         token(T_LNUMBER)->as('expr'),
-        chain(token(T_LIST), token('('), layer()->as('array_pair_list'), token(')'), operator('='), $expr)->as('expr'),
+        chain(
+            chain(token(T_LIST), token('('), layer()->as('array_pair_list'), token(')'))->as('left'),
+            operator('=')->as('operator'),
+            $expr->as('right')
+        )->as('expr'),
         chain(token('['), layer()->as('array_pair_list'), token(']'))->as('expr'),
-        chain(variable(), phpOperator(), $expr)->as('expr'),
-        chain(variable(), operator('='), token('&'), variable())->as('expr'),
+        chain(
+            variable()->as('left'),
+            phpOperator()->as('operator'),
+            $expr->as('right')
+        )->as('expr'),
+        chain(
+            variable()->as('left'),
+            operator('=')->as('operator'),
+            chain(token('&'), variable())->as('right')
+        )->as('expr'),
         chain(token(T_CLONE), $expr)->as('expr'),
-        chain(chain(variable(), indentation())->as('left'), chain(token(T_INSTANCEOF)->as('operator'), chain(indentation(), ns())->as('right')))->as('expr'),
-        chain(token('('), $expr, token(')')),
+        chain(
+            chain(variable(), indentation())->as('left'),
+            token(T_INSTANCEOF)->as('operator'),
+            chain(indentation(), ns())->as('right')
+        )->as('expr'),
+        chain(token('('), $expr, token(')'))->as('expr'),
         variable()->as('expr')
     );
 }

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -76,7 +76,7 @@ function expr(): Parser
         chain(variable(), phpOperator(), $expr)->as('expr'),
         chain(variable(), operator('='), token('&'), variable())->as('expr'),
         chain(token(T_CLONE), $expr)->as('expr'),
-        chain(variable()->as('var'), chain(token(T_INSTANCEOF)->as('instanceof'), ns()->as('fqcn')))->as('expr'),
+        chain(chain(variable(), indentation())->as('left'), chain(token(T_INSTANCEOF)->as('operator'), chain(indentation(), ns())->as('right')))->as('expr'),
         chain(token('('), $expr, token(')')),
         variable()->as('expr')
     );

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -71,6 +71,7 @@ function expr(): Parser
 
     return either(
         token(T_LNUMBER)->as('expr'),
+        token(T_DNUMBER)->as('expr'),
         chain(
             chain(token(T_LIST), token('('), layer()->as('array_pair_list'), token(')'))->as('left'),
             operator('=')->as('operator'),

--- a/tests/phpt/expr/array_lnumber.phpt
+++ b/tests/phpt/expr/array_lnumber.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() array of T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+[1, 2, 3]
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    [1, 2, 3]
+}
+
+?>

--- a/tests/phpt/expr/clone.phpt
+++ b/tests/phpt/expr/clone.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() array of T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+clone $a
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    clone$a
+}
+
+?>

--- a/tests/phpt/expr/dnumber.phpt
+++ b/tests/phpt/expr/dnumber.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() D_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+42.0
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    42.0
+}
+
+?>

--- a/tests/phpt/expr/instanceof.phpt
+++ b/tests/phpt/expr/instanceof.phpt
@@ -11,14 +11,14 @@ expression {
 }
 }
 
-$a instanceof \Some\Large\FQCN
+$a   instanceof \Some\Large\FQCN
 
 ?>
 --EXPECTF--
 <?php
 
 expression {
-    $ainstanceof\Some\Large\FQCN
+    $a   instanceof \Some\Large\FQCN
 }
 
 ?>

--- a/tests/phpt/expr/instanceof.phpt
+++ b/tests/phpt/expr/instanceof.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test variables and operators expressions
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+$a instanceof \Some\Large\FQCN
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    $ainstanceof\Some\Large\FQCN
+}
+
+?>

--- a/tests/phpt/expr/list_assign.phpt
+++ b/tests/phpt/expr/list_assign.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() array of T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+list($a, $b, $c) = [1, 2, 3]
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    list($a, $b, $c)=[1, 2, 3]
+}
+
+?>

--- a/tests/phpt/expr/lnumber.phpt
+++ b/tests/phpt/expr/lnumber.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+42
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    42
+}
+
+?>

--- a/tests/phpt/expr/parentesis.phpt
+++ b/tests/phpt/expr/parentesis.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() array of T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+([1, 2, 3])
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    ([1, 2, 3])
+}
+
+?>

--- a/tests/phpt/expr/variable.phpt
+++ b/tests/phpt/expr/variable.phpt
@@ -1,0 +1,24 @@
+--TEST--
+test for ·expr() array of T_LNUMBER
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+$a
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    $a
+}
+
+?>

--- a/tests/phpt/expr/variable_and_operator.phpt
+++ b/tests/phpt/expr/variable_and_operator.phpt
@@ -1,0 +1,156 @@
+--TEST--
+test variables and operators expressions
+--FILE--
+<?php
+
+macro {
+   ·expr()·my_expr
+} >> {
+expression {
+    ·my_expr
+}
+}
+
+$a = 42
+$a + 42
+$a - 42
+$a * 42
+$a / 42
+$a % 42
+$a ^ 42
+$a | 42
+$a & 42
+$a ** 42
+$b = &$a
+$a += 1
+$a >> 42
+$a << 42
+$a += 42
+$a -= 42
+$a *= 42
+$a **= 42
+$a /= 42
+$a .= 42
+$a %= 42
+$a &= 42
+$a |= 42
+$a ^= 42
+$a <<= 42
+$a >>= 42
+$a == 42
+$a === 42
+$a >= 42
+$a != 42
+$a !== 42
+$a <= 42
+$a == 42
+$a <=> 42
+
+?>
+--EXPECTF--
+<?php
+
+expression {
+    $a=42
+}
+expression {
+    $a+42
+}
+expression {
+    $a-42
+}
+expression {
+    $a*42
+}
+expression {
+    $a/42
+}
+expression {
+    $a%42
+}
+expression {
+    $a^42
+}
+expression {
+    $a|42
+}
+expression {
+    $a&42
+}
+expression {
+    $a**42
+}
+expression {
+    $b=&$a
+}
+expression {
+    $a+=1
+}
+expression {
+    $a>>42
+}
+expression {
+    $a<<42
+}
+expression {
+    $a+=42
+}
+expression {
+    $a-=42
+}
+expression {
+    $a*=42
+}
+expression {
+    $a**=42
+}
+expression {
+    $a/=42
+}
+expression {
+    $a.=42
+}
+expression {
+    $a%=42
+}
+expression {
+    $a&=42
+}
+expression {
+    $a|=42
+}
+expression {
+    $a^=42
+}
+expression {
+    $a<<=42
+}
+expression {
+    $a>>=42
+}
+expression {
+    $a==42
+}
+expression {
+    $a===42
+}
+expression {
+    $a>=42
+}
+expression {
+    $a!=42
+}
+expression {
+    $a!==42
+}
+expression {
+    $a<=42
+}
+expression {
+    $a==42
+}
+expression {
+    $a<=>42
+}
+
+?>


### PR DESCRIPTION
TODO
------

This is the todo of what the expression parser should cover based this [grammar](https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L872-L991) available on the PHP repo.

 - [x] variable
 - [x] T_LNUMBER
 - [x] T_DNUMBER
 - [ ] other_scalar_expr
 - [x] T_LIST ( array_pair_list )
 - [x] array_pair_list
 - [x] variable phpOperator expr
 - [ ] expr phpOperator expr
 - [x] variable = & variable
 - [x] T_CLONE expr
 - [x] variable instanceof ns()
 - [ ] expr instanceof ns()
 - [x] ( expr )
 - [ ] new_expr | new anonumous class
 - [ ] ternary_expr
 - [ ] expr '?' ':' expr
 - [ ] expr T_COALESCE expr
 - [ ] casting expr
 - [ ] '@' expr
 - [ ] '`' backticks_expr '`'
 - [ ] T_PRINT expr
 - [ ] T_YIELD | T_YIELD expr | T_YIELD expr T_DOUBLE_ARROW expr | T_YIELD_FROM expr
 - [ ] anonymous function