### PR TITLE
chore: makes the dependency `docopt/docopt` optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,10 @@
         "php": "7.*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "nikic/php-parser": "^2.1|^3.0|^4.0",
-        "docopt/docopt": "^1.0"
+        "nikic/php-parser": "^2.1|^3.0|^4.0"
+    },
+    "suggest": {
+        "docopt/docopt": "Allows the usage of the command line tool `bin/yay`"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
This pull request makes the dependency `docopt/docopt` optional - as most of the libraries that depend of this project don't use the command line tool.

If you agree with this, I can also update the docs accordingly. 