### PR TITLE
Remove composer self-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ sudo: false
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - composer self-update
   - composer require satooshi/php-coveralls:~2.0.0 --no-update --dev
   - composer install --prefer-source
 


### PR DESCRIPTION
Travis does this automatically, so no reason to do it twice