### PR TITLE
Allow composer to work on nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ sudo: false
 before_script:
   - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - composer require satooshi/php-coveralls:~2.0.0 --no-update --dev
-  - composer install --prefer-source
+  - if [[ $TRAVIS_PHP_VERSION = nightly ]]; then export COMPOSER_FLAGS=" --ignore-platform-reqs"; fi
+  - composer update $COMPOSER_FLAGS
+  - composer require satooshi/php-coveralls:~2.0.0 --no-update --dev $COMPOSER_FLAGS
+  - composer install --prefer-source $COMPOSER_FLAGS
 
 script:
   - php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ sudo: false
 before_script:
   - phpenv config-rm xdebug.ini || true
   - if [[ $TRAVIS_PHP_VERSION = nightly ]]; then export COMPOSER_FLAGS=" --ignore-platform-reqs"; fi
-  - composer update $COMPOSER_FLAGS
   - composer require satooshi/php-coveralls:~2.0.0 --no-update --dev $COMPOSER_FLAGS
   - composer install --prefer-source $COMPOSER_FLAGS
 


### PR DESCRIPTION
The platform is incompatible with php 8, so we tell composer to ignore it (for now)